### PR TITLE
add type declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare const config: any;
+export default config;


### PR DESCRIPTION
This is just to make sure that typescript projects won't complain about an "implicit any", now it's an explicit any 😂 

There really is no way to define a more strict type definition for this addon because it completely depends on the config object in your repo 👍 