### PR TITLE
Use ternary instead of if statement in module export

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,11 +1,5 @@
 import { isTesting, macroCondition, getOwnConfig } from '@embroider/macros';
 
-let config;
-
-if (macroCondition(isTesting())) {
-  config = getOwnConfig().testConfig;
-} else {
-  config = getOwnConfig().config;
-}
-
-export default config;
+export default macroCondition(isTesting())
+  ? getOwnConfig().testConfig
+  : getOwnConfig().config;


### PR DESCRIPTION
This fixes an issue we are seeing when building apps in production mode. This issue was introduced in version 1.0.3 with PR #35.

Before this change, when building in production mode, we would not get the config from the app:
 
<img width="898" alt="Screen Shot 2022-04-13 at 5 48 24 PM" src="https://user-images.githubusercontent.com/230476/163292758-4a61c844-87ee-4a5e-8c37-de3be444e8ff.png">
<img width="492" alt="Screen Shot 2022-04-13 at 5 48 14 PM" src="https://user-images.githubusercontent.com/230476/163292760-b5ff6377-f703-4ac6-bf99-c988c8ba1b5f.png">


Now with this change, we get the config in production and all other modes:

<img width="645" alt="Screen Shot 2022-04-13 at 5 43 24 PM" src="https://user-images.githubusercontent.com/230476/163292802-02f83c19-bffe-4a61-beee-82c9cb339a52.png">



Paired with @eugenioenko. 
