### PR TITLE
breaking: re-export configModule to reduce duplication and fix dynamic config

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,11 +1,5 @@
-import { isTesting, macroCondition, getOwnConfig } from '@embroider/macros';
+import { getOwnConfig, importSync } from '@embroider/macros';
 
-let config;
+let configModulePath = `${getOwnConfig().modulePrefix}/config/environment`;
 
-if (macroCondition(isTesting())) {
-  config = getOwnConfig().testConfig;
-} else {
-  config = getOwnConfig().config;
-}
-
-export default config;
+export default importSync(configModulePath).default;

--- a/index.js
+++ b/index.js
@@ -28,11 +28,7 @@ module.exports = {
   included() {
     this._super.included.apply(this, arguments);
 
-    this.options['@embroider/macros'].setOwnConfig.config = findRoot(
-      this
-    ).project.config(process.env.EMBER_ENV);
-
-    this.options['@embroider/macros'].setOwnConfig.testConfig =
-      findRoot(this).project.config('test');
+    this.options['@embroider/macros'].setOwnConfig.modulePrefix =
+      findRoot(this).project.config().modulePrefix;
   },
 };


### PR DESCRIPTION
Thanks to @pichfl for the pairing session and deep-diving into ember-cli to get this super neat 👨‍🍳 💋 

This is only breaking because if you were relying on dynamic config changes (by altering the config HTML) then before this PR it wasn't working, and now because of this PR it is working 🎉 

Fixes https://github.com/mansona/ember-get-config/issues/39
Fixes https://github.com/mansona/ember-get-config/pull/40