### PR TITLE
Use `require` to retrieve the app's config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
         './testem.js',
         './blueprints/*/index.js',
         './config/**/*.js',
+        './lib/**/*.js',
         './tests/dummy/config/**/*.js',
       ],
       parserOptions: {

--- a/.npmignore
+++ b/.npmignore
@@ -26,6 +26,7 @@
 /CONTRIBUTING.md
 /ember-cli-build.js
 /testem.js
+/lib/baz/
 /tests/
 /yarn-error.log
 /yarn.lock

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,6 @@
-import { getOwnConfig, importSync } from '@embroider/macros';
+/* global require */
+import { getOwnConfig } from '@embroider/macros';
 
 let configModulePath = `${getOwnConfig().modulePrefix}/config/environment`;
 
-let config = importSync(configModulePath);
-
-// fix problem with fastboot config being wrapped in a second "default" object
-export default config.default?.default ?? config.default;
+export default require(configModulePath).default;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,6 +16,11 @@ module.exports = function (defaults) {
 
   const { maybeEmbroider } = require('@embroider/test-setup');
   return maybeEmbroider(app, {
+    compatAdapters: new Map(
+      Object.entries({
+        'ember-get-config': null,
+      })
+    ),
     skipBabel: [
       {
         package: 'qunit',

--- a/lib/baz/config/environment.js
+++ b/lib/baz/config/environment.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function (/* environment, appConfig */) {
+  return {
+    baz: 'qux',
+  };
+};

--- a/lib/baz/index.js
+++ b/lib/baz/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  name: require('./package').name,
+
+  isDevelopingAddon() {
+    return true;
+  },
+};

--- a/lib/baz/package.json
+++ b/lib/baz/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "baz",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "paths": [
+      "lib/baz"
+    ]
   }
 }

--- a/tests/acceptance/ember-get-config-test.js
+++ b/tests/acceptance/ember-get-config-test.js
@@ -10,4 +10,10 @@ module('Acceptance | ember get config', function (hooks) {
 
     assert.equal(find('#foo').innerText.trim(), 'bar', 'text correct');
   });
+
+  test('it includes config from addons', async function (assert) {
+    await visit('/');
+
+    assert.dom('#baz').hasText('qux');
+  });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -3,5 +3,6 @@ import Controller from '@ember/controller';
 import config from 'ember-get-config';
 
 export default Controller.extend({
+  baz: config.baz,
   foo: config.foo,
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,2 @@
+<div id="baz">{{this.baz}}</div>
 <div id="foo">{{this.foo}}</div>

--- a/tests/fastboot/basic-test.js
+++ b/tests/fastboot/basic-test.js
@@ -7,6 +7,6 @@ module('FastBoot | basic', function (hooks) {
   test('it renders a page...', async function (assert) {
     let { htmlDocument } = await visit('/');
 
-    assert.dom('body', htmlDocument).hasText('bar');
+    assert.dom('body', htmlDocument).hasText('qux bar');
   });
 });

--- a/tests/unit/ember-get-config-test.js
+++ b/tests/unit/ember-get-config-test.js
@@ -1,3 +1,4 @@
+import configApp from 'dummy/config/environment';
 import config from 'ember-get-config';
 import { module, test } from 'qunit';
 
@@ -5,4 +6,8 @@ module('ember-get-config');
 
 test('it exports the app config file', function (assert) {
   assert.equal(config.environment, 'test');
+});
+
+test("it exports a reference to the app's config", function (assert) {
+  assert.equal(config, configApp);
 });


### PR DESCRIPTION
This uses loader.js's `require` function to retrieve the app's environment config. This bypasses the `importSync` dependency checking that happens in Embroider builds which causes the build to fail since the dependency doesn't exist in the addon.

I included the commits of #42, #43 and #44 so that I could test it still works under all those new tests. I'll rebase after those are merged.