### PR TITLE
Resolve missing addon warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,6 @@ module.exports = {
         './testem.js',
         './blueprints/*/index.js',
         './config/**/*.js',
-        './lib/**/*.js',
         './tests/dummy/config/**/*.js',
       ],
       parserOptions: {

--- a/.npmignore
+++ b/.npmignore
@@ -26,7 +26,6 @@
 /CONTRIBUTING.md
 /ember-cli-build.js
 /testem.js
-/lib/baz/
 /tests/
 /yarn-error.log
 /yarn.lock

--- a/lib/baz/config/environment.js
+++ b/lib/baz/config/environment.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = function (/* environment, appConfig */) {
-  return {
-    baz: 'qux',
-  };
-};

--- a/lib/baz/index.js
+++ b/lib/baz/index.js
@@ -1,9 +1,0 @@
-'use strict';
-
-module.exports = {
-  name: require('./package').name,
-
-  isDevelopingAddon() {
-    return true;
-  },
-};

--- a/lib/baz/package.json
+++ b/lib/baz/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "baz",
-  "keywords": [
-    "ember-addon"
-  ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "broccoli-asset-rev": "^3.0.0",
         "ember-auto-import": "^2.3.0",
         "ember-cli": "~3.28.2",
+        "ember-cli-app-version": "^5.0.0",
         "ember-cli-dependency-checker": "^3.2.0",
         "ember-cli-fastboot": "^3.3.0",
         "ember-cli-fastboot-testing": "^0.6.0",
@@ -9351,6 +9352,19 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ember-cli-app-version": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-5.0.0.tgz",
+      "integrity": "sha512-afhx/CXDOMNXzoe4NDPy5WUfxWmYYHUzMCiTyvPBxCDBXYcMrtxNWxvgaSaeqcoHVEmqzeyBj8V82tzmT1dcyw==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.23.1",
+        "git-repo-info": "^2.1.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
       }
     },
     "node_modules/ember-cli-babel": {
@@ -32468,6 +32482,16 @@
           "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
           "dev": true
         }
+      }
+    },
+    "ember-cli-app-version": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-5.0.0.tgz",
+      "integrity": "sha512-afhx/CXDOMNXzoe4NDPy5WUfxWmYYHUzMCiTyvPBxCDBXYcMrtxNWxvgaSaeqcoHVEmqzeyBj8V82tzmT1dcyw==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.23.1",
+        "git-repo-info": "^2.1.1"
       }
     },
     "ember-cli-babel": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.3.0",
     "ember-cli": "~3.28.2",
+    "ember-cli-app-version": "^5.0.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-fastboot": "^3.3.0",
     "ember-cli-fastboot-testing": "^0.6.0",
@@ -79,9 +80,6 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "paths": [
-      "lib/baz"
-    ]
+    "configPath": "tests/dummy/config"
   }
 }

--- a/tests/acceptance/ember-get-config-test.js
+++ b/tests/acceptance/ember-get-config-test.js
@@ -14,6 +14,6 @@ module('Acceptance | ember get config', function (hooks) {
   test('it includes config from addons', async function (assert) {
     await visit('/');
 
-    assert.dom('#baz').hasText('qux');
+    assert.dom('#app-name').hasText('ember-get-config');
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -3,6 +3,6 @@ import Controller from '@ember/controller';
 import config from 'ember-get-config';
 
 export default Controller.extend({
-  baz: config.baz,
+  appName: config.APP.name,
   foo: config.foo,
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,2 +1,2 @@
-<div id="baz">{{this.baz}}</div>
+<div id="app-name">{{this.appName}}</div>
 <div id="foo">{{this.foo}}</div>

--- a/tests/fastboot/basic-test.js
+++ b/tests/fastboot/basic-test.js
@@ -7,6 +7,6 @@ module('FastBoot | basic', function (hooks) {
   test('it renders a page...', async function (assert) {
     let { htmlDocument } = await visit('/');
 
-    assert.dom('body', htmlDocument).hasText('qux bar');
+    assert.dom('body', htmlDocument).hasText('ember-get-config bar');
   });
 });


### PR DESCRIPTION
PR https://github.com/mansona/ember-get-config/pull/45 introduced an in-repo addon for testing purposes, but because the in-repo addon isn't published, Ember CLI displays a warning because the `lib/baz` path is still included in the published `package.json` file.

This PR switches to using `ember-cli-app-version` instead of the custom in-repo addon.
Different addon, but we still test the same functionality.

Resolves https://github.com/mansona/ember-get-config/pull/45#issuecomment-1169549041.