### PR TITLE
add a config helper

### DIFF
--- a/addon/helpers/config.js
+++ b/addon/helpers/config.js
@@ -1,0 +1,15 @@
+import { getOwner } from '@ember/application';
+import Helper from '@ember/component/helper';
+import { get } from '@ember/object';
+
+export default class extends Helper {
+  constructor() {
+    super(...arguments);
+
+    this.config = getOwner(this).resolveRegistration('config:environment');
+  }
+
+  compute([path]) {
+    return get(this.config, path);
+  }
+}

--- a/app/helpers/config.js
+++ b/app/helpers/config.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-get-config/helpers/config';

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,6 +19,7 @@ module.exports = function (environment) {
     },
 
     APP: {
+      name: 'ember-get-config',
       // Here you can pass flags/options to your application instance
       // when it is created
     },

--- a/tests/integration/helpers/config-test.js
+++ b/tests/integration/helpers/config-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | config', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the correct value', async function (assert) {
+    await render(hbs`{{config "APP.name"}}`);
+
+    assert.equal(this.element.textContent.trim(), 'ember-get-config');
+  });
+});


### PR DESCRIPTION
As promised at emberfest: the PR :)
This is extracted from https://github.com/nvdk/ember-config-helper  and  provides a convenience helper to access the application config from within the template. This is useful for template only components mostly. 

At the moment the helper doesn't use the config import provided by ember-get-config, this can be adjusted if that makes more sense.